### PR TITLE
Support for PHP8.1 - wrong property type

### DIFF
--- a/src/Export/ExportBase.php
+++ b/src/Export/ExportBase.php
@@ -90,7 +90,7 @@ abstract class ExportBase extends BaseClient
             $url .= '?' . http_build_query($parameters);
         }
         
-        return $this->apiClient->get($url, null);
+        return $this->apiClient->get($url, []);
     }
 
     /**


### PR DESCRIPTION
Bokbasen\ApiClient\Client::get(): Argument #2 ($headers) must be of type array, null given, called in /var/www/html/vendor/bokbasen/php-sdk-met-api/src/Export/ExportBase.php on line 93#